### PR TITLE
Fixed github warning about set-output deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,10 +36,10 @@ jobs:
             RELEASE_FLAG=ON
           fi
 
-          echo "::set-output name=project_ver::$PROJECT_VERSION"
-          echo "::set-output name=build_ver::$BUILD_VERSION"
-          echo "::set-output name=full_ver::$PROJECT_VERSION-$BUILD_VERSION"
-          echo "::set-output name=release_flag::$RELEASE_FLAG"
+          echo "project_ver=$PROJECT_VERSION" >>$GITHUB_OUTPUT
+          echo "build_ver=$BUILD_VERSION" >>$GITHUB_OUTPUT
+          echo "full_ver=$PROJECT_VERSION-$BUILD_VERSION" >>$GITHUB_OUTPUT
+          echo "release_flag=$RELEASE_FLAG" >>$GITHUB_OUTPUT
 
       - name: Display versions
         run: |


### PR DESCRIPTION
Replace this text with your description here...

# Code-Reviewer Section

The general pull request guidelines can be found [here](https://github.com/apple/foundationdb/wiki/FoundationDB-Commit-Process).

Please check each of the following things and check *all* boxes before accepting a PR.

- [ ] The PR has a description, explaining both the problem and the solution.
- [ ] The description mentions which forms of testing were done and the testing seems reasonable.
- [ ] Every function/class/actor that was touched is reasonably well documented.

## For Release-Branches

If this PR is made against a release-branch, please also check the following:

- [ ] This change/bugfix is a cherry-pick from the next younger branch (younger `release-branch` or `main` if this is the youngest branch)
- [ ] There is a good reason why this PR needs to go into a release branch and this reason is documented (either in the description above or in a linked GitHub issue)
