### PR TITLE
Revert "Try to fix Python 3.11 incapability with Sphinx 1.5.6" because it is not compatible with cmake 3.16

### DIFF
--- a/cmake/FDBComponents.cmake
+++ b/cmake/FDBComponents.cmake
@@ -107,7 +107,7 @@ endif()
 ################################################################################
 
 option(BUILD_DOCUMENTATION "build documentation" ON)
-find_package(Python3 3.0...<3.11 COMPONENTS Interpreter)
+find_package(Python3 COMPONENTS Interpreter)
 if (WITH_PYTHON AND Python3_Interpreter_FOUND AND BUILD_DOCUMENTATION)
   set(WITH_DOCUMENTATION ON)
 else()


### PR DESCRIPTION
This reverts commit 6d2f06cd1276cbdb2def90f242ddb1a7df29ee1f.

Earlier @1inker added a version range for python, but this feature (version ranges) startred supporting only in cmake 3.19.

Now ubuntu 3.18 is used for builds that ships with cmake 3.16.

Githube runners bring a newer cmake version, but it is not reproducible in local builds against a upure ubuntu 3.16. So I reverted that change.