### PR TITLE
Fixed build errors on a pure ubuntu 18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,9 @@ jobs:
         shell: bash
         run: |
           sudo apt update
-          sudo apt install -y sudo git cmake g++ build-essential libssl-dev default-jdk python3 python3-pip liblz4-dev ninja-build rpm clang-10
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y sudo git cmake g++ build-essential libssl-dev default-jdk python3 python3-pip liblz4-dev ninja-build rpm clang-10 clang python3-venv
           sudo pip3 install virtualenv
-          sudo apt install -y dirmngr gnupg apt-transport-https ca-certificates
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y dirmngr gnupg apt-transport-https ca-certificates
           sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
           sudo sh -c 'echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" > /etc/apt/sources.list.d/mono-official-stable.list'
           sudo apt update


### PR DESCRIPTION
Earlier @1inker has added additional things to build, but that things require additional software to be installed. It is already at github runners, but they must be installed explicitely in a pure ubuntu-18.

I added installing that software on build.