### PR TITLE
XDB-144 Disabled building docker images on intermediate github builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
 
   publish_images:
     needs: [calc_ver, build]
+    if: ${{ needs.calc_ver.outputs.release_flag == 'ON' }}
     runs-on: ubuntu-latest
     env:
       DOCKER_REGISTRY: ghcr.io


### PR DESCRIPTION
Because keeping docker images take a lot of resources, now only release builds publish them