### PR TITLE
Added checking for the github version correctness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             for: linux
             prepare: "debian-based"
             build_on: linux
-            use_image: ghcr.io/owtech/foundationdb-build:6.3.25-5.ow.1
+            use_image: ghcr.io/owtech/foundationdb-build:7.2.5-0.ow.2
             parallel: 3
 
     runs-on: ${{ matrix.run_on }}

--- a/.github/workflows/make-build-image.yml
+++ b/.github/workflows/make-build-image.yml
@@ -3,7 +3,7 @@ name: Make a build image
 
 on:
   push:
-    branches: ["ow-build-image*"]
+    tags: ["*.ow-build-image"]
 
 jobs:
   calc_ver:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ message(STATUS "Current git version ${CURRENT_GIT_VERSION}")
 ################################################################################
 # Version information
 ################################################################################
+if(DEFINED VERSION AND NOT VERSION STREQUAL CMAKE_PROJECT_VERSION)
+  message(FATAL_ERROR "The version parameter ${VERSION} differs from the project version ${CMAKE_PROJECT_VERSION}")
+endif()
 if (FDB_RELEASE_CANDIDATE)
     set(FDB_RELEASE_CANDIDATE_VERSION 1 CACHE STRING "release candidate version")
     set(FDB_VERSION ${PROJECT_VERSION}-rc${FDB_RELEASE_CANDIDATE_VERSION})


### PR DESCRIPTION
Earlier when the git version tag was incorrect, the github build failed after two hours.

Now the version correctness is chached at the beginning of build.