### PR TITLE
Added checking for the github version correctness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ message(STATUS "Current git version ${CURRENT_GIT_VERSION}")
 ################################################################################
 # Version information
 ################################################################################
+if(DEFINED VERSION AND NOT VERSION STREQUAL CMAKE_PROJECT_VERSION)
+  message(FATAL_ERROR "The version parameter ${VERSION} differs from the project version ${CMAKE_PROJECT_VERSION}")
+endif()
 if (FDB_RELEASE_CANDIDATE)
     set(FDB_RELEASE_CANDIDATE_VERSION 1 CACHE STRING "release candidate version")
     set(FDB_VERSION ${PROJECT_VERSION}-rc${FDB_RELEASE_CANDIDATE_VERSION})


### PR DESCRIPTION
Earlier when the git version tag was incorrect, the github build failed after two hours.

Now the version correctness is chached at the beginning of build.
