### PR TITLE
Reduced number of parallel threads of build from 3 to 2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             prepare: "debian-based"
             build_on: linux
             use_image: ghcr.io/owtech/foundationdb-build:7.3.0-1.ow.build
-            parallel: 3
+            parallel: 4
 
     runs-on: ${{ matrix.run_on }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             prepare: "debian-based"
             build_on: linux
             use_image: ghcr.io/owtech/foundationdb-build:7.3.0-1.ow.build
-            parallel: 4
+            parallel: 2
 
     runs-on: ${{ matrix.run_on }}
     steps:


### PR DESCRIPTION
Seems clang 13 requires more resources (memory?), then 10 and 12, so builds fail.

I reduced the number of parallel threads from 3 to 2. It increased the build time from 2 h to 2h 40m, but the build finishes successfully.