### PR TITLE
XDB-218 Added new commit statistics metrics

### DIFF
--- a/fdbserver/CommitProxyServer.actor.cpp
+++ b/fdbserver/CommitProxyServer.actor.cpp
@@ -797,6 +797,7 @@ ACTOR Future<Void> preresolutionProcessing(CommitBatchContext* self) {
 			r->value().emplace_back(versionReply.resolverChangesVersion, it.dest);
 	}
 
+	pProxyCommitData->stats.commitPreresolutionLatency.addMeasurement(now() - timeStart);
 	//TraceEvent("ProxyGotVer", pProxyContext->dbgid).detail("Commit", commitVersion).detail("Prev", prevVersion);
 
 	if (debugID.present()) {
@@ -864,7 +865,10 @@ ACTOR Future<Void> getResolution(CommitBatchContext* self) {
 	std::vector<ResolveTransactionBatchReply> resolutionResp = wait(getAll(replies));
 	self->resolution.swap(*const_cast<std::vector<ResolveTransactionBatchReply>*>(&resolutionResp));
 
-	self->pProxyCommitData->stats.resolutionDist->sampleSeconds(now() - resolutionStart);
+	double resolutionDuration = now() - resolutionStart;
+
+	self->pProxyCommitData->stats.commitResolutionLatency.addMeasurement(resolutionDuration);
+	self->pProxyCommitData->stats.resolutionDist->sampleSeconds(resolutionDuration);
 	if (self->debugID.present()) {
 		g_traceBatch.addEvent(
 		    "CommitDebug", self->debugID.get().first(), "CommitProxyServer.commitBatch.AfterResolution");
@@ -1442,7 +1446,10 @@ ACTOR Future<Void> postResolution(CommitBatchContext* self) {
 		}
 	}
 
-	pProxyCommitData->stats.processingMutationDist->sampleSeconds(now() - postResolutionQueuing);
+	double postResolutionEnd = now();
+
+	pProxyCommitData->stats.commitPostresolutionLatency.addMeasurement(postResolutionEnd - postResolutionStart);
+	pProxyCommitData->stats.processingMutationDist->sampleSeconds(postResolutionEnd - postResolutionQueuing);
 	return Void();
 }
 
@@ -1481,7 +1488,11 @@ ACTOR Future<Void> transactionLogging(CommitBatchContext* self) {
 		pProxyCommitData->txsPopVersions.emplace_back(self->commitVersion, self->msg.popTo);
 	}
 	pProxyCommitData->logSystem->popTxs(self->msg.popTo);
-	pProxyCommitData->stats.tlogLoggingDist->sampleSeconds(now() - tLoggingStart);
+
+	double tLoggingDuration = now() - tLoggingStart;
+
+	pProxyCommitData->stats.commitTLogLoggingLatency.addMeasurement(tLoggingDuration);
+	pProxyCommitData->stats.tlogLoggingDist->sampleSeconds(tLoggingDuration);
 	return Void();
 }
 
@@ -1595,6 +1606,7 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 		// TODO: filter if pipelined with large commit
 		const double duration = endTime - tr.requestTime();
 		pProxyCommitData->stats.commitLatencySample.addMeasurement(duration);
+		pProxyCommitData->stats.commitBatchingWaiting.addMeasurement(self->startTime - tr.requestTime());
 		if (pProxyCommitData->latencyBandConfig.present()) {
 			bool filter = self->maxTransactionBytes >
 			              pProxyCommitData->latencyBandConfig.get().commitConfig.maxCommitBytes.orDefault(
@@ -1651,7 +1663,11 @@ ACTOR Future<Void> reply(CommitBatchContext* self) {
 	pProxyCommitData->commitBatchesMemBytesCount -= self->currentBatchMemBytesCount;
 	ASSERT_ABORT(pProxyCommitData->commitBatchesMemBytesCount >= 0);
 	wait(self->releaseFuture);
-	pProxyCommitData->stats.replyCommitDist->sampleSeconds(now() - replyStart);
+
+	double replyDuration = now() - replyStart;
+
+	pProxyCommitData->stats.commitReplyLatency.addMeasurement(replyDuration);
+	pProxyCommitData->stats.replyCommitDist->sampleSeconds(replyDuration);
 	return Void();
 }
 
@@ -1673,6 +1689,8 @@ ACTOR Future<Void> commitBatch(ProxyCommitData* self,
 	context.pProxyCommitData->lastVersionTime = context.startTime;
 	++context.pProxyCommitData->stats.commitBatchIn;
 	context.setupTraceBatch();
+	context.pProxyCommitData->stats.commitBatchBytes.addMeasurement(context.currentBatchMemBytesCount);
+	context.pProxyCommitData->stats.commitBatchTransactions.addMeasurement(context.trs.size());
 
 	/////// Phase 1: Pre-resolution processing (CPU bound except waiting for a version # which is separately pipelined
 	/// and *should* be available by now (unless empty commit); ordered; currently atomic but could yield)

--- a/fdbserver/ProxyCommitData.actor.h
+++ b/fdbserver/ProxyCommitData.actor.h
@@ -70,6 +70,19 @@ struct ProxyStats {
 
 	LatencySample commitBatchingWindowSize;
 
+	// Number of transactions in the batch
+	LatencySample commitBatchTransactions;
+	// Summary length of transactions in the batch
+	LatencySample commitBatchBytes;
+	// what time transactions were waiting in the batch before they
+	// started processing with commitBatch()
+	LatencySample commitBatchingWaiting;
+	LatencySample commitPreresolutionLatency;
+	LatencySample commitResolutionLatency;
+	LatencySample commitPostresolutionLatency;
+	LatencySample commitTLogLoggingLatency;
+	LatencySample commitReplyLatency;
+
 	LatencySample computeLatency;
 
 	Future<Void> logger;
@@ -125,6 +138,38 @@ struct ProxyStats {
 	                             id,
 	                             SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
 	                             SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitBatchTransactions("CommitBatchTransactions",
+	                            id,
+	                            SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                            SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitBatchBytes("CommitBatchBytes",
+	                     id,
+	                     SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                     SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitBatchingWaiting("CommitBatchingWaiting",
+	                          id,
+	                          SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                          SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitPreresolutionLatency("CommitPreresolutionLatency",
+	                               id,
+	                               SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                               SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitResolutionLatency("CommitResolutionLatency",
+	                            id,
+	                            SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                            SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitPostresolutionLatency("CommitPostresolutionLatency",
+	                                id,
+	                                SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                                SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitTLogLoggingLatency("CommitTLogLoggingLatency",
+	                             id,
+	                             SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                             SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
+	    commitReplyLatency("CommitReplyLatency",
+	                       id,
+	                       SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,
+	                       SERVER_KNOBS->LATENCY_SAMPLE_SIZE),
 	    computeLatency("ComputeLatency",
 	                   id,
 	                   SERVER_KNOBS->LATENCY_METRICS_LOGGING_INTERVAL,

--- a/fdbserver/Status.actor.cpp
+++ b/fdbserver/Status.actor.cpp
@@ -653,6 +653,46 @@ struct RolesInfo {
 			if (commitBatchingWindowSize.size()) {
 				obj["commit_batching_window_size"] = addLatencyStatistics(commitBatchingWindowSize);
 			}
+
+			TraceEventFields const& commitBatchTransactions = metrics.at("CommitBatchTransactions");
+			if (commitBatchTransactions.size()) {
+				obj["commit_batch_transactions"] = addLatencyStatistics(commitBatchTransactions);
+			}
+
+			TraceEventFields const& commitBatchBytes = metrics.at("CommitBatchBytes");
+			if (commitBatchBytes.size()) {
+				obj["commit_batch_bytes"] = addLatencyStatistics(commitBatchBytes);
+			}
+
+			TraceEventFields const& commitBatchingWaiting = metrics.at("CommitBatchingWaiting");
+			if (commitBatchingWaiting.size()) {
+				obj["commit_batching_waiting"] = addLatencyStatistics(commitBatchingWaiting);
+			}
+
+			TraceEventFields const& commitPreresolutionLatency = metrics.at("CommitPreresolutionLatency");
+			if (commitPreresolutionLatency.size()) {
+				obj["commit_preresolution_latency"] = addLatencyStatistics(commitPreresolutionLatency);
+			}
+
+			TraceEventFields const& commitResolutionLatency = metrics.at("CommitResolutionLatency");
+			if (commitResolutionLatency.size()) {
+				obj["commit_resolution_latency"] = addLatencyStatistics(commitResolutionLatency);
+			}
+
+			TraceEventFields const& commitPostresolutionLatency = metrics.at("CommitPostresolutionLatency");
+			if (commitPostresolutionLatency.size()) {
+				obj["commit_postresolution_latency"] = addLatencyStatistics(commitPostresolutionLatency);
+			}
+
+			TraceEventFields const& commitTLogLoggingLatency = metrics.at("CommitTLogLoggingLatency");
+			if (commitTLogLoggingLatency.size()) {
+				obj["commit_tlog_logging_latency"] = addLatencyStatistics(commitTLogLoggingLatency);
+			}
+
+			TraceEventFields const& commitReplyLatency = metrics.at("CommitReplyLatency");
+			if (commitReplyLatency.size()) {
+				obj["commit_reply_latency"] = addLatencyStatistics(commitReplyLatency);
+			}
 		} catch (Error& e) {
 			if (e.code() != error_code_attribute_not_found) {
 				throw e;
@@ -1993,10 +2033,20 @@ ACTOR static Future<std::vector<std::pair<TLogInterface, EventMap>>> getTLogsAnd
 ACTOR static Future<std::vector<std::pair<CommitProxyInterface, EventMap>>> getCommitProxiesAndMetrics(
     Reference<AsyncVar<ServerDBInfo>> db,
     std::unordered_map<NetworkAddress, WorkerInterface> address_workers) {
-	std::vector<std::pair<CommitProxyInterface, EventMap>> results = wait(getServerMetrics(
-	    db->get().client.commitProxies,
-	    address_workers,
-	    std::vector<std::string>{ "CommitLatencyMetrics", "CommitLatencyBands", "CommitBatchingWindowSize" }));
+	std::vector<std::pair<CommitProxyInterface, EventMap>> results =
+	    wait(getServerMetrics(db->get().client.commitProxies,
+	                          address_workers,
+	                          std::vector<std::string>{ "CommitLatencyMetrics",
+	                                                    "CommitLatencyBands",
+	                                                    "CommitBatchingWindowSize",
+	                                                    "CommitBatchTransactions",
+	                                                    "CommitBatchBytes",
+	                                                    "CommitBatchingWaiting",
+	                                                    "CommitPreresolutionLatency",
+	                                                    "CommitResolutionLatency",
+	                                                    "CommitPostresolutionLatency",
+	                                                    "CommitTLogLoggingLatency",
+	                                                    "CommitReplyLatency" }));
 
 	return results;
 }


### PR DESCRIPTION
# Problem statement

Now it is hard to tune a fdb cluster for a write-intensive workload.

# Description

While tuning a fdb cluster with a write-intensive application often the bottleneck is the commit latency: when trying to parallel degree of transactions payload, the commit latency grows and prevents increasing the transaction throughput.

There are lots of conditions and knobs influencing the commit latency: number of commit proxies, number of resolvers, number of tlog processes, commit batching knobs: MAX_COMMIT_BATCH_INTERVAL, COMMIT_TRANSACTION_BATCH_INTERVAL_MAX, COMMIT_TRANSACTION_BATCH_INTERVAL_SMOOTHER_ALPHA and others.

But for now, there is no any information, where is the root cause of the high commit latency, so it is unclear, what is to be changed.

# Proposal

- To collect and to log latency statistics from parts of commit workflow:
    - Waiting for a batch
    - Preresolution (allocating a commit version)
    - Resolution
    - Postresolution
    - Pushing to TLog
    - Replying
- To collect and log the batch size statistics
    - The number of transactions in one batch
    - The total bytes in the transaction batch

# PR content

This PR implements this proposal: the following new metrics are logged and exposed in ``status json``:
- CommitBatchTransactions (commit_batch_transactions) - the number of transactions in one batch
- CommitBatchBytes (commit_batch_bytes) - the total size of one commit batch in bytes
- CommitBatchingWaiting (commit_batching_waiting) - the time while the transaction is waiting for the batch becomes ready
- CommitPreresolutionLatency (commit_preresolution_latency) - the time of the Preresolution phase
- CommitResolutionLatency (commit_resolution_latency) - the time of the Resolution phase
- CommitPostResolutionLatency (commit_resolution_latency) - the time of the Postresolution phase
- CommitTLogLoggingLatency (commit_tlog_logging_latency) - the time of the TlogLogging phase
- CommitReplyLatency (commit_reply_latency) - the time of Reply phase

The sum of the added *_latency_mean metrics should be equal to the commit_latency_mean metrics that already exists

# Upstream PR
https://github.com/apple/foundationdb/pull/10993