### PR TITLE
exclude flag "exec in stack" for fdb_c library

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -53,7 +53,7 @@ if(APPLE)
   target_link_options(fdb_c PRIVATE "LINKER:-no_weak_exports,-exported_symbols_list,${symbols}")
 elseif(WIN32)
 else()
-  target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map,-z,nodelete")
+  target_link_options(fdb_c PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/fdb_c.map,-z,nodelete,-z,noexecstack")
 endif()
 target_include_directories(fdb_c PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>


### PR DESCRIPTION
Fix for Astra Linux error (forbidden in PARSEC module): 
"Exception in thread "main" java.lang.UnsatisfiedLinkError: /tmp/fdb_java17229827326188843993.library: libfdb_c.so: cannot enable executable stack as shared object requires: Permission denied"

