### PR TITLE
fix "Unknown error" when  configuring regions

### DIFF
--- a/fdbclient/DatabaseConfiguration.cpp
+++ b/fdbclient/DatabaseConfiguration.cpp
@@ -397,7 +397,9 @@ std::string DatabaseConfiguration::configureStringFromJSON(const StatusObject& j
 			continue;
 		}
 
-		result += " ";
+		if (!result.empty()) {
+			result += " ";
+		}
 		// All integers are assumed to be actual DatabaseConfig keys and are set with
 		// the hidden "<name>:=<intValue>" syntax of the configure command.
 		if (kv.second.type() == json_spirit::int_type) {
@@ -440,7 +442,10 @@ std::string DatabaseConfiguration::configureStringFromJSON(const StatusObject& j
 	// explicit log_engine we simply add " log_engine=ssd-2" to the output string if the input JSON did not contain a
 	// log_engine.
 	if (!json.contains("log_engine")) {
-		result += " log_engine=ssd-2";
+		if (!result.empty()) {
+			result += " ";
+		}
+		result += "log_engine=ssd-2";
 	}
 
 	return result;


### PR DESCRIPTION
When executing the command "fdbcli --exec 'fileconfigure..." the error message "ERROR: unknown parameter" is displayed.
The error occurred in
ConfigurationResult buildConfiguration(std::vector<StringRef> const& modeTokens, std::map<std::string, std::string>& outConf);
since the vector of modeTokens included reference to an empty string that got into the vector in the function
ConfigurationResult buildConfiguration(std::string const& configMode, std::map<std::string, std::string>& outConf); 
since the configMode begins from empty string which added in
std::string DatabaseConfiguration::configureStringFromJSON(const StatusObject& json)