### PR TITLE
XDB-312 fix warning message in multiregion recovery process

### DIFF
--- a/cmake/CompileBoost.cmake
+++ b/cmake/CompileBoost.cmake
@@ -73,7 +73,7 @@ function(compile_boost)
 
   set(BOOST_INSTALL_DIR "${CMAKE_BINARY_DIR}/boost_install")
   ExternalProject_add("${COMPILE_BOOST_TARGET}Project"
-    URL                "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2"
+    URL                "https://archives.boost.io/release/1.78.0/source/boost_1_78_0.tar.bz2"
     URL_HASH           SHA256=8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
     CONFIGURE_COMMAND  ${BOOTSTRAP_COMMAND}
                        ${BOOTSTRAP_ARGS}

--- a/fdbcli/StatusCommand.actor.cpp
+++ b/fdbcli/StatusCommand.actor.cpp
@@ -694,11 +694,9 @@ void printStatus(StatusObjectReader statusObj,
 
 						if (dataLoss == -1) {
 							ASSERT_WE_THINK(availLoss == -1);
-							outputString += format(
-							    "\n\n  Warning: the database may have data loss and availability loss. Please restart "
-							    "following tlog interfaces, otherwise storage servers may never be able to catch "
-							    "up.\n");
 							StatusObjectReader logs;
+							std::string epoches_data;
+							std::optional<int> satellite_log_fault_tolerance;
 							if (statusObjCluster.has("logs")) {
 								for (StatusObjectReader logEpoch : statusObjCluster.last().get_array()) {
 									bool possiblyLosingData;
@@ -713,6 +711,12 @@ void printStatus(StatusObjectReader statusObj,
 									logEpoch.get("begin_version", beginVersion);
 									logEpoch.get("end_version", endVersion);
 									logEpoch.get("current", current);
+									if (int sat_log_fault_tolerance; logEpoch.get("satellite_log_fault_tolerance", sat_log_fault_tolerance)) {
+										if (!satellite_log_fault_tolerance) {
+											satellite_log_fault_tolerance = 0;
+										}
+										satellite_log_fault_tolerance = std::min(sat_log_fault_tolerance, *satellite_log_fault_tolerance);
+									}
 									std::string missing_log_interfaces;
 									if (logEpoch.has("log_interfaces")) {
 										for (StatusObjectReader logInterface : logEpoch.last().get_array()) {
@@ -721,11 +725,11 @@ void printStatus(StatusObjectReader statusObj,
 											if (logInterface.get("healthy", healthy) && !healthy) {
 												logInterface.get("id", id);
 												logInterface.get("address", address);
-												missing_log_interfaces += format("%s,%s ", id.c_str(), address.c_str());
+												missing_log_interfaces += format("%s,%s ", id.c_str(), address.empty() ? "unknown" : address.c_str());
 											}
 										}
 									}
-									outputString += format(
+									epoches_data += format(
 									    "  %s log epoch: %lld begin: %lld end: %s, missing "
 									    "log interfaces(id,address): %s\n",
 									    current ? "Current" : "Old",
@@ -735,6 +739,12 @@ void printStatus(StatusObjectReader statusObj,
 									    missing_log_interfaces.c_str());
 								}
 							}
+							outputString += format("\n\n  ");
+							if (!satellite_log_fault_tolerance || (satellite_log_fault_tolerance && *satellite_log_fault_tolerance < 0)) {
+								outputString += format("Warning: the database may have data loss and availability loss. ");
+							}
+							outputString += format("Please restart following tlog interfaces, otherwise storage servers may never be able to catch up.\n");
+							outputString += epoches_data;
 						}
 					}
 				}


### PR DESCRIPTION
"the database may have data loss and availability loss" will not be displayed in `fdbcli --exec "status details"` if satellite_log_fault_tolerance is exist and `satellite_log_fault_tolerance >= 0` in all epochs. Since the presence of a satellite allows data recovery.
