### PR TITLE
Xdb 452 7.4.5 fix size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
             ${{needs.calc_ver.outputs.release_flag}} \
             ${{ matrix.parallel }}
 
-          echo "=== Disk space after build ==="
+          echo "=== Disk space after build and cpack ==="
           df -h
 
       # - name: Minimal tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             for: linux
             prepare: "debian-based"
             build_on: linux
-            parallel: 2
+            parallel: 5
             image: foundationdb-build:7.4.1-0.ow.build
             owner: ${GITHUB_REPOSITORY_OWNER@L}
     runs-on: ${{ matrix.run_on }}
@@ -63,17 +63,19 @@ jobs:
 
       - name: Build
         run: |
-          mkdir -p ${{github.workspace}}/bld
-          chmod 777 ${{github.workspace}}/bld
+          sudo mkdir -p /mnt/bld
+          sudo chmod 777 /mnt/bld
+
           echo "=== Disk space before build ==="
           df -h
+
           podman run --rm \
             --name build \
             --mount=type=tmpfs,dst=/tmp \
             --mount=type=tmpfs,dst=/var/tmp \
             --security-opt label=disable \
             --mount=type=bind,src=${{github.workspace}},dst=/home/runner/src,readonly \
-            --mount=type=bind,src=${{github.workspace}}/bld,dst=/home/runner/bld \
+            --mount=type=bind,src=/mnt/bld,dst=/home/runner/bld \
             $use_image \
             /home/runner/src/build-scripts/for-${{ matrix.for }}/build-on-${{ matrix.build_on }}.bash \
             ${{needs.calc_ver.outputs.project_ver}} \
@@ -81,8 +83,11 @@ jobs:
             ${{needs.calc_ver.outputs.release_flag}} \
             ${{ matrix.parallel }}
 
+          echo "=== Disk space after build ==="
+          df -h
+
       # - name: Minimal tests
-      #  working-directory: ${{github.workspace}}/bld
+      #  working-directory: /mnt/bld
       #  shell: bash
       #  run: ctest --output-on-failure -V
 
@@ -90,7 +95,7 @@ jobs:
         uses: nanoufo/action-upload-artifacts-and-release-assets@v2
         with:
           path: |
-            ${{github.workspace}}/bld/linux/packages/*${{needs.calc_ver.outputs.full_ver}}*
+            /mnt/bld/linux/packages/*${{needs.calc_ver.outputs.full_ver}}*
           upload-release-files: ${{ needs.calc_ver.outputs.release_flag }}
           release-upload-url: ${{ needs.calc_ver.outputs.release_upload_url }}
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             for: linux
             prepare: "debian-based"
             build_on: linux
-            parallel: 5
+            parallel: 2
             image: foundationdb-build:7.4.1-0.ow.build
             owner: ${GITHUB_REPOSITORY_OWNER@L}
     runs-on: ${{ matrix.run_on }}
@@ -65,6 +65,8 @@ jobs:
         run: |
           mkdir -p ${{github.workspace}}/bld
           chmod 777 ${{github.workspace}}/bld
+          echo "=== Disk space before build ==="
+          df -h
           podman run --rm \
             --name build \
             --mount=type=tmpfs,dst=/tmp \

--- a/build-scripts/for-linux/build-on-linux.bash
+++ b/build-scripts/for-linux/build-on-linux.bash
@@ -61,7 +61,7 @@ echo "number of parallel jobs: [$PARALLEL_PRMS]"
 ninja $PARALLEL_PRMS -k 0
 
 echo "=== Disk space after build ==="
-df -h 
+df -h
 
 cpack -G RPM
 for fn in packages/*.rpm; do echo "$fn:"; rpm -qpRv $fn; echo; done

--- a/build-scripts/for-linux/build-on-linux.bash
+++ b/build-scripts/for-linux/build-on-linux.bash
@@ -60,6 +60,9 @@ echo "number of parallel jobs: [$PARALLEL_PRMS]"
 
 ninja $PARALLEL_PRMS -k 0
 
+echo "=== Disk space after build ==="
+df -h 
+
 cpack -G RPM
 for fn in packages/*.rpm; do echo "$fn:"; rpm -qpRv $fn; echo; done
 

--- a/documentation/CMakeLists.txt
+++ b/documentation/CMakeLists.txt
@@ -56,7 +56,7 @@ function(add_documentation_target)
     COMMAND
       ${Sphinx_EXECUTABLE} -W -b ${TARGET} -d ${DOCTREE} -c
       ${SPHINX_DOCUMENT_DIR} ${SPHINX_DOCUMENT_DIR}/source ${OUTPUT_DIR}
-      -Dversion=${FDB_VERSION} -Drelease=${FDB_RELEASE}
+      -Dversion=${FDB_VERSION} -Drelease=${FDB_VERSION}
     COMMAND ${CMAKE_COMMAND} -E touch ${STAMP_FILE}
     DEPENDS ${DOC_FILES}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
An error occurs when start running "cpack -G RPM" after successfully building  
```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251121-133008-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
```
```
=== Disk space before build ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   53G   19G  74% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda16      881M   62M  758M   8% /boot
/dev/sda15      105M  6.2M   99M   6% /boot/efi
/dev/sdb1        74G  4.1G   66G   6% /mnt    <---- now is building here
tmpfs           1.6G   12K  1.6G   1% /run/user/1001 
```